### PR TITLE
Fixed highlighting for sequences in shell command

### DIFF
--- a/syntax/sxhkdrc.vim
+++ b/syntax/sxhkdrc.vim
@@ -6,13 +6,14 @@ syntax include @Shell syntax/sh.vim
 
 syn match sxComment "^#.*$"
 syn match sxHotkey "[^ #].*" contains=sxKeysym,sxModifier,sxHotkeySep,sxSequence
-syn match sxCommand "^\s.*$" containedin=ALL contains=@Shell
+syn match sxCommand "^\s.*$" containedin=ALL contains=@Shell,sxSequenceShell
 syn keyword sxModifier super hyper meta alt control ctrl shift mode_switch lock mod1 mod2 mod3 mod4 mod5 any contained
 syn match sxKeysym "[^ :;{,}+-]\+" contained contains=sxAction
 syn match sxAction "[@!~/]" contained
 syn match sxHotkeySep "[;:+]" contained
 syn match sxSequenceSep "[,-]" contained
 syn region sxSequence matchgroup=sxBrace start=/{/ end=/}/ contained keepend oneline contains=sxKeysym,sxModifier,sxHotkeySep,sxSequenceSep
+syn region sxSequenceShell matchgroup=sxBrace start=/{/ end=/}/ contained keepend oneline contains=sxKeysym,sxSequenceSep
 
 hi def link sxComment Comment
 hi def link sxModifier Keyword


### PR DESCRIPTION
Had a problem where the highlighting stopped working after this shell command:

```
bspc {desktop --focus,window --to-desktop} {9,7,5,3,1,0,2,4,6,8}
```

Also this PR makes it easier to see sequences in commands.
