### PR TITLE
Added commentstring=#%s

### DIFF
--- a/ftdetect/sxhkdrc.vim
+++ b/ftdetect/sxhkdrc.vim
@@ -2,4 +2,4 @@ if &compatible || v:version < 603
     finish
 endif
 
-autocmd BufNewFile,BufRead sxhkdrc,*.sxhkdrc set ft=sxhkdrc
+autocmd BufNewFile,BufRead sxhkdrc,*.sxhkdrc set ft=sxhkdrc cms=#%s


### PR DESCRIPTION
Now sets correct commentstring automatically

Important for plugins like https://github.com/tpope/vim-commentary