### PR TITLE
Move setting options to ftplugin

### DIFF
--- a/ftdetect/sxhkdrc.vim
+++ b/ftdetect/sxhkdrc.vim
@@ -2,4 +2,4 @@ if &compatible || v:version < 603
     finish
 endif
 
-autocmd BufNewFile,BufRead sxhkdrc,*.sxhkdrc set ft=sxhkdrc cms=#%s
+autocmd BufNewFile,BufRead sxhkdrc,*.sxhkdrc set ft=sxhkdrc

--- a/ftplugin/sxhkdrc.vim
+++ b/ftplugin/sxhkdrc.vim
@@ -1,0 +1,1 @@
+setlocal cms=#%s


### PR DESCRIPTION
This is the proper place to set it as shown by for example https://github.com/vim/vim/blob/master/runtime/syntax/fortran.vim